### PR TITLE
Fix conflict with built-in keyboard shortcut on OS X

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,6 @@
 [
-	{ "keys": ["f8"], 			"command": "camaleon", "args":{"type":"next"}},
-	{ "keys": ["shift+f8"], "command": "camaleon", "args":{"type":"previous"}},
+    { "keys": ["f8"],       "command": "camaleon", "args":{"type":"next"}},
+    { "keys": ["shift+f8"], "command": "camaleon", "args":{"type":"previous"}},
 
-	{ "keys": ["ctrl+f8"], "command": "camaleon_random_colour_scheme"}
+    { "keys": ["alt+f8"],   "command": "camaleon_random_colour_scheme"}
 ]


### PR DESCRIPTION
`Control`+`F8` on Mac is the shortcut to the menubar icons. Sublime Text can't override this.
This changes it to `Option`+`F8` instead on OS X.
